### PR TITLE
Refactor/min max scaler api consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.2]
+
+:bug: API consistency update :bug:
+
+- **enhance:** MinMaxScaler now implements `transform` and `fit_transform` correctly accroding to ScikitLearn MinMaxScaler
+
 ## [2.0.1]
 
 :rocket: feature implementations :rocket:

--- a/src/lib/preprocessing/data.ts
+++ b/src/lib/preprocessing/data.ts
@@ -395,9 +395,18 @@ export class OneHotEncoder {
  * import { MinMaxScaler } from 'machinelearn/preprocessing';
  *
  * const minmaxScaler = new MinMaxScaler({ featureRange: [0, 1] });
+ *
+ * // Fitting an 1D matrix
  * minmaxScaler.fit([4, 5, 6]);
- * const result = minmaxScaler.fit_transform([4, 5, 6]);
- * // [ 0, 0.5, 1 ]
+ * const result = minmaxScaler.transform([4, 5, 6]);
+ * // result = [ 0, 0.5, 1 ]
+ *
+ * // Fitting a 2D matrix
+ * const minmaxScaler2 = new MinMaxScaler({ featureRange: [0, 1] });
+ * minmaxScaler2.fit([[1, 2, 3], [4, 5, 6]]);
+ * const result2 = minmaxScaler2.transform([[1, 2, 3]]);
+ * // result2 = [ [ 0, 0.2, 0.4000000000000001 ] ]
+ *
  */
 export class MinMaxScaler {
   private featureRange: number[];

--- a/src/lib/preprocessing/data.ts
+++ b/src/lib/preprocessing/data.ts
@@ -428,7 +428,7 @@ export class MinMaxScaler {
    * Compute the minimum and maximum to be used for later scaling.
    * @param {number[]} X - Array or sparse-matrix data input
    */
-  public fit(X: Type1DMatrix<number> | Type2DMatrix<number>): void {
+  public fit(X: Type1DMatrix<number> | Type2DMatrix<number> = null): void {
     let rowMax = tf.tensor(X);
     let rowMin = tf.tensor(X);
     const xShape = inferShape(X);
@@ -452,12 +452,37 @@ export class MinMaxScaler {
 
   /**
    * Fit to data, then transform it.
-   * @param {number[]} X - Original input vector
+   * @param X - Original input vector
    */
-  public fit_transform(X: Type1DMatrix<number> = null): number[] {
-    validateMatrix1D(X);
-    const X1 = X.map(x => x * this.scale);
-    return X1.map(x => x + this.baseMin);
+  public fit_transform(
+    X: Type1DMatrix<number> | Type2DMatrix<number>
+  ): number[] | number[][] {
+    this.fit(X);
+    return this.transform(X);
+  }
+
+  /**
+   * Scaling features of X according to feature_range.
+   * @param X - Original input vector
+   */
+  public transform(
+    X: Type1DMatrix<number> | Type2DMatrix<number> = null
+  ): number[] | number[][] {
+    // Transforms a single vector
+    const transform_single = _X => {
+      const X1 = _X.map(x => x * this.scale);
+      return X1.map(x => x + this.baseMin);
+    };
+    const shapes = inferShape(X);
+    if (shapes.length === 2) {
+      return (X as number[][]).map(z => transform_single(z));
+    } else if (shapes.length === 1) {
+      return transform_single(X);
+    } else {
+      throw new TypeError(
+        `The input shape ${JSON.stringify(shapes)} cannot be transformed`
+      );
+    }
   }
 
   /**

--- a/src/lib/preprocessing/index.repl.ts
+++ b/src/lib/preprocessing/index.repl.ts
@@ -23,6 +23,11 @@ minmaxScaler.fit([4, 5, 6]);
 const result = minmaxScaler.fit_transform([4, 5, 6]);
 console.log('minmax result', result);
 
+const minmaxScaler2 = new MinMaxScaler({ featureRange: [0, 1] });
+minmaxScaler2.fit([[1, 2, 3], [4, 5, 6]]);
+const result2 = minmaxScaler2.transform([[1, 2, 3]]);
+console.log('minmax result 2', result2);
+
 // Imputer
 import { Imputer } from './Imputer';
 

--- a/test/preprocessing/data.test.ts
+++ b/test/preprocessing/data.test.ts
@@ -138,7 +138,7 @@ describe('data:MinMaxScaler', () => {
     ];
     const scaler = new MinMaxScaler({ featureRange: [0, 1] });
     scaler.fit(matrix1);
-    const result = scaler.fit_transform([1, 2, 3]);
+    const result = scaler.transform([1, 2, 3]);
     expect(result).toEqual(expected);
   });
   it('should transform matrix1 then successfully inverse tranform', () => {
@@ -150,7 +150,7 @@ describe('data:MinMaxScaler', () => {
     const scaler = new MinMaxScaler({ featureRange: [0, 1] });
     scaler.fit(matrix1);
     const data = [1, 2, 3];
-    const transformed = scaler.fit_transform(data);
+    const transformed = scaler.transform(data);
     expect(transformed).toEqual(expected);
     const result = scaler.inverse_transform(transformed);
     expect(result).toEqual(data);
@@ -165,10 +165,10 @@ describe('data:MinMaxScaler', () => {
     const scaler = new MinMaxScaler({ featureRange: [0, 1] });
     expect(() => scaler.fit_transform('?')).toThrow(tensorErr);
     expect(() => scaler.fit_transform(1)).toThrow(
-      'The matrix is not 1D shaped: 1 of []'
+      'Cannot fit with an empty value'
     );
     expect(() => scaler.fit_transform([])).toThrow(
-      'The matrix is not 1D shaped: [] of [0]'
+      'Cannot fit with an empty value'
     );
   });
   it('should not inverse_transform invalid inputs', () => {


### PR DESCRIPTION
Updating MinMaxScaler API

1. `transform` -> transforms a vector or matrix
2. `fit_transform` -> trains and transforms a matrix