### PR TITLE
Chore: update base image in Dockerfile; remove tmux from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM node:8.12.0
+FROM node:8.15.1-stretch
 MAINTAINER Jason Shin <visualbbasic@gmail.com>
 
 # System Deps
 RUN apt-get update -y
-RUN apt-get install tmux -y
 RUN apt-get clean
 
 ENV CORE /home/node/app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machinelearn",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Machine Learning library for the web and Node",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
Node base image in Dockerfile is bumped to 8.15.1-stretch due to removal of Wheezy and Jessie from mirrors(https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html). Also removed unnecessary tmux dependency.