### PR TITLE
Add LabelEncoder in the export

### DIFF
--- a/src/lib/preprocessing/index.ts
+++ b/src/lib/preprocessing/index.ts
@@ -2,4 +2,6 @@ import { add_dummy_feature, Binarizer, MinMaxScaler, normalize, OneHotEncoder, P
 
 import { Imputer } from './Imputer';
 
-export { add_dummy_feature, Binarizer, MinMaxScaler, normalize, OneHotEncoder, PolynomialFeatures, Imputer };
+import { LabelEncoder } from './label';
+
+export { add_dummy_feature, Binarizer, MinMaxScaler, normalize, OneHotEncoder, PolynomialFeatures, Imputer, LabelEncoder };


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add 'LabelEncoder' in the preprocessing export


* **What is the current behavior?** (You can also link to an open issue here)
LabelEncoder functionality is missing during import.


* **What is the new behavior (if this is a feature change)?**
LabelEncoder now is able to used in import from processing folder.


* **Other information**:
None.